### PR TITLE
Implement additional UDP connection on same port between client <> server

### DIFF
--- a/Battle/Gameplay.cpp
+++ b/Battle/Gameplay.cpp
@@ -607,8 +607,6 @@ void Gameplay::process_player_collission() {
 				// Therefore (re)set a timer that will periodically send our data to server.
 				// But we cannot do this 
 				if (Main::runmode == MainRunModes::CLIENT && ServerClient::getInstance().isConnected()) {
-					CommandSetPlayerData mydata;
-
 					if (ServerClient::getInstance().getClientId() == p1->number || ServerClient::getInstance().getClientId() == p2->number) {
 						ServerClient::getInstance().resetTimer();
 					}

--- a/Battle/Main.cpp
+++ b/Battle/Main.cpp
@@ -341,9 +341,9 @@ int Main::run(const MainRunModes &runmode)
 
 				Server::getInstance().initializeLevel();
 				
-				Server::getInstance().registerServer();
-
 				Server::getInstance().listen();
+
+				Server::getInstance().registerServer();
 
 				multiplayer.run();
 			}

--- a/Battle/NetworkMultiplayer.cpp
+++ b/Battle/NetworkMultiplayer.cpp
@@ -51,7 +51,7 @@ void NetworkMultiplayer::on_game_reset()
 
 		CommandSetPlayerData pd;
 		level_util::set_player_start(player, *level);
-		player_util::set_position_data(pd, player.number, server.getServerTime(), player);
+		player_util::set_position_data(pd, player.number, server.getServerTime(), server.getUdpSeq(), player);
 		server.sendAll(pd);
 
 		CommandSetHitPoints points;
@@ -154,7 +154,7 @@ void NetworkMultiplayer::on_post_processing()
 					// Unset input's for players, do not change location yet
 					player_util::unset_input(player);
 					CommandSetPlayerData pd;
-					player_util::set_position_data(pd, player.number, server.getServerTime(), player);
+					player_util::set_position_data(pd, player.number, server.getServerTime(), server.getUdpSeq(), player);
 					server.sendAll(pd);
 				}
 			}

--- a/Battle/Player.h
+++ b/Battle/Player.h
@@ -49,7 +49,7 @@ class CommandSetPlayerData;
 class Player;
 namespace player_util
 {
-	void set_position_data(CommandSetPlayerData &data, char client_id, Uint32 time, Player &player);
+	void set_position_data(CommandSetPlayerData &data, char client_id, Uint32 time, short udpseq, Player &player);
 	void set_player_data(Player &player, CommandSetPlayerData &data, bool skip_input = false);
 	Player &get_player_by_id(char client_id);
 	void unset_input(Player &player);

--- a/Battle/commands/CommandSetCommunicationToken.hpp
+++ b/Battle/commands/CommandSetCommunicationToken.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include "network/Command.hpp"
+
+class CommandSetCommunicationToken : public Command
+{
+public:
+
+	CommandSetCommunicationToken() : Command(Command::Types::SetCommunicationToken) 
+	{
+		memset(&data, 0x00, sizeof(data));
+	}
+	~CommandSetCommunicationToken() {	}
+
+	virtual void * getData() { return &data; };
+	virtual size_t getDataLen() { return sizeof(data); };
+
+	struct
+	{
+		Uint32 time;
+		uint64_t commToken;
+	} data;
+};

--- a/Battle/commands/CommandSetPlayerData.hpp
+++ b/Battle/commands/CommandSetPlayerData.hpp
@@ -17,6 +17,7 @@ public:
 
 	struct
 	{
+		short udp_sequence;
 		char client_id;
 		Uint32 time;
 		short flags;

--- a/Battle/network/Client.h
+++ b/Battle/network/Client.h
@@ -56,7 +56,10 @@ public:
 	void send(Command &command);
 
 	void cleanup(); 
-	
+
+	Uint64 getCommToken() { return commToken_; }
+	short getLastUdpSeq() { return lastUdpSeq_; }
+
 	// lag
 	Uint32 getLastLagTime() { return lastLagTime_; }
 	void setLastLagTime(Uint32 time) { lastLagTime_ = time; }
@@ -80,4 +83,7 @@ private:
 	int initialLagTests_;
 
 	Client::State currentState_;
+
+	Uint64 commToken_;
+	short lastUdpSeq_;
 };

--- a/Battle/network/ClientNetworkMultiplayer.cpp
+++ b/Battle/network/ClientNetworkMultiplayer.cpp
@@ -161,7 +161,7 @@ void ClientNetworkMultiplayer::on_input_handled()
 	short previous_flags = flags;
 		
 	CommandSetPlayerData req;
-	player_util::set_position_data(req, ServerClient::getInstance().getClientId(), SDL_GetTicks(), player);
+	player_util::set_position_data(req, ServerClient::getInstance().getClientId(), SDL_GetTicks(), ServerClient::getInstance().getUdpSeq(), player);
 
 	flags = req.data.flags;
 

--- a/Battle/network/Command.hpp
+++ b/Battle/network/Command.hpp
@@ -30,7 +30,8 @@ public:
 		SetGameStart = 0x13,
 		GeneratePowerup = 0x14,
 		ApplyPowerup = 0x15,
-		RemovePowerup = 0x16
+		RemovePowerup = 0x16,
+		SetCommunicationToken = 0x17,
 	};
 
 	Command::Types getType() const { return type_; }

--- a/Battle/network/Commands.cpp
+++ b/Battle/network/Commands.cpp
@@ -52,6 +52,8 @@ std::unique_ptr<Command> Command::factory(Command::Types type)
 			return std::unique_ptr<Command>(new CommandApplyPowerup());
 		case Command::Types::RemovePowerup:
 			return std::unique_ptr<Command>(new CommandRemovePowerup());
+		case Command::Types::SetCommunicationToken:
+			return std::unique_ptr<Command>(new CommandSetCommunicationToken());
 	}
 	throw std::runtime_error("failure");
 }

--- a/Battle/network/Commands.hpp
+++ b/Battle/network/Commands.hpp
@@ -22,3 +22,4 @@
 #include "commands/CommandGeneratePowerup.h"
 #include "commands/CommandApplyPowerup.hpp"
 #include "commands/CommandRemovePowerup.hpp"
+#include "commands/CommandSetCommunicationToken.hpp"

--- a/Battle/network/Server.h
+++ b/Battle/network/Server.h
@@ -1,7 +1,7 @@
 #pragma once
 
 #include <map>
- 
+
 #include "SDL/SDL_net.h"
 
 #include "network/Client.h"
@@ -13,15 +13,13 @@ class NetworkMultiplayer;
 
 #include "util/ServerUtil.h"
 
-class Server
-{
+class Server {
 public:
 
-    static Server& getInstance()
-    {
-        static Server instance;
-        return instance;
-    }
+	static Server& getInstance() {
+		static Server instance;
+		return instance;
+	}
 
 	// Server listens
 	void listen();
@@ -34,17 +32,30 @@ public:
 
 	void setState(const ServerState * const state);
 
-	Level &getLevel() { return level_; }
-	std::string getLevelName() { return levelName_; }
+	Level &getLevel() {
+		return level_;
+	}
+
+	std::string getLevelName() {
+		return levelName_;
+	}
 	void setLevel(std::string level);
-	void setPort(int port) { port_ = (Uint16)port; };
-	void setName(std::string name) { servername_ = name; };
+
+	void setPort(int port) {
+		port_ = (Uint16) port;
+	};
+
+	void setName(std::string name) {
+		servername_ = name;
+	};
 
 	void initializeLevel();
 	void registerServer();
 	void initializeGame(NetworkMultiplayer &);
 
-	Uint32 getServerTime() { return serverTime_; }
+	Uint32 getServerTime() {
+		return serverTime_;
+	}
 
 	Gameplay &getGame();
 	Client& getClientById(int client_id);
@@ -52,27 +63,46 @@ public:
 
 	void sendAll(Command &command);
 
-	void ignoreClientInputFor(int ms) { ignoreClientInputUntil_ = serverTime_ + ms; }
-	bool ignoreClientInput() { return ignoreClientInputUntil_ > serverTime_; }
-	
-	std::string getName() { return servername_; }
-	int getPort() { return port_; }
+	void ignoreClientInputFor(int ms) {
+		ignoreClientInputUntil_ = serverTime_ + ms;
+	}
+
+	bool ignoreClientInput() {
+		return ignoreClientInputUntil_ > serverTime_;
+	}
+
+	std::string getName() {
+		return servername_;
+	}
+
+	int getPort() {
+		return port_;
+	}
+
+	short getUdpSeq() {
+		return udpsequence_;
+	}
+
+	void setNextUdpSeq() {
+		udpsequence_++;
+	}
 
 private:
-    Server();
+	Server();
 	~Server();
-	
+
 	// Prevent copies of server
 	Server(Server const&); // Don't implement
-    void operator=(Server const&); // Don't implement
+	void operator=(Server const&); // Don't implement
 
 	SDLNet_SocketSet create_sockset();
 
-	
+
 	bool is_listening_;
 
 	std::map<int, Client> clients_;
-	
+	std::map<Uint64, int> communicationTokens_;
+
 	TCPsocket server;
 
 	IPaddress ip;
@@ -88,11 +118,16 @@ private:
 	NetworkMultiplayer *game_;
 
 	const ServerState * currentState_;
-	
+
 	Uint32 serverTime_;
 	Uint32 ignoreClientInputUntil_;
 
 	std::string serverToken_;
-	
+
+	// UDP
+	UDPsocket sd; /* Socket descriptor */
+	UDPpacket *p; /* Pointer to packet memory */
+	short udpsequence_;
+
 	friend class ClientNetworkMultiplayer;
 };

--- a/Battle/network/ServerClient.h
+++ b/Battle/network/ServerClient.h
@@ -49,6 +49,7 @@ class CommandSetGameStart;
 class CommandGeneratePowerup;
 class CommandApplyPowerup;
 class CommandRemovePowerup;
+class CommandSetCommunicationToken;
 
 class ServerClient : public CommandProcessor
 {
@@ -109,6 +110,9 @@ public:
 
 	void resumeGameIn(short delay);
 
+	short getUdpSeq() { return udpsequence_; }
+	void setNextUdpSeq() { udpsequence_++; }
+
 protected:
 	bool process(std::unique_ptr<Command> command);
 	
@@ -132,7 +136,9 @@ protected:
 	bool process(CommandGeneratePowerup *command);
 	bool process(CommandApplyPowerup *command);
 	bool process(CommandRemovePowerup *command);
+	bool process(CommandSetCommunicationToken *command);
 
+	
 private:
 	ServerClient();
 	~ServerClient();
@@ -177,4 +183,10 @@ private:
 	Uint32 lastResetTimer_;
 	bool resumeGameWithCountdown_;
 	Uint32 resumeGameTime_;
+
+
+	// UDP STUFF
+	UDPsocket sd;
+	Uint64 communicationToken_;
+	short udpsequence_;
 };

--- a/Battle/states/ServerStateAcceptClients.cpp
+++ b/Battle/states/ServerStateAcceptClients.cpp
@@ -63,6 +63,10 @@ void ServerStateAcceptClients::execute(Server &server, Client &client) const
 					CommandRequestCharacter req;
 					client.send(req);
 
+					CommandSetCommunicationToken commtok;
+					commtok.data.commToken = client.getCommToken();
+					client.send(commtok);
+
 					client.setState(Client::State::CHARACTER_REQUESTED);
 				}
 				break;
@@ -129,7 +133,7 @@ void ServerStateAcceptClients::execute(Server &server, Client &client) const
 
 						// Send the client "player data"
 						CommandSetPlayerData playerpos;
-						player_util::set_position_data(playerpos, player.number, server.getServerTime(), player);
+						player_util::set_position_data(playerpos, player.number, server.getServerTime(), server.getUdpSeq(), player);
 						client.send(playerpos);
 
 						// Send the client player 's health
@@ -176,7 +180,7 @@ void ServerStateAcceptClients::execute(Server &server, Client &client) const
 					level_util::set_player_start(player, level);
 
 					CommandSetPlayerData pd;
-					player_util::set_position_data(pd, client.getClientId(), server.getServerTime(), player);
+					player_util::set_position_data(pd, client.getClientId(), server.getServerTime(), server.getUdpSeq(), player);
 					server.sendAll(pd);
 
 					player.is_dead = false;

--- a/Battle/states/ServerStateGameStarted.cpp
+++ b/Battle/states/ServerStateGameStarted.cpp
@@ -50,7 +50,7 @@ void ServerStateGameStarted::initialize(Server &server) const
 
 		// Set their correct positions
 		CommandSetPlayerData pd;
-		player_util::set_position_data(pd, player.number, server.getServerTime(), player);
+		player_util::set_position_data(pd, player.number, server.getServerTime(), server.getUdpSeq(), player);
 		server.sendAll(pd);
 
 		CommandSetPlayerAmmo ammo;

--- a/Battle/util/Log.cpp
+++ b/Battle/util/Log.cpp
@@ -7,13 +7,13 @@ std::vector<std::string> Logger::console;
 
 std::string format(const char *format, ...)
 {
-    char buffer[4086] = {0x00};
+	char buffer[4086] = {0x00};
 
-    va_list args;
-    va_start(args, format);
-    vsprintf(buffer, format, args);
-    va_end(args);
+	va_list args;
+	va_start(args, format);
+	vsprintf(buffer, format, args);
+	va_end(args);
 
-    return std::string(buffer);
+	return std::string(buffer);
 }
 

--- a/Battle/util/PlayerUtil.cpp
+++ b/Battle/util/PlayerUtil.cpp
@@ -10,9 +10,8 @@
 
 namespace player_util
 {
-	void set_position_data(CommandSetPlayerData &playerpos, char client_id, Uint32 time, Player &player)
+	void set_position_data(CommandSetPlayerData &playerpos, char client_id, Uint32 time, short udpseq, Player &player)
 	{
-
 		// todo: remove param client_id, it is always player.number (!)
 		short flags = 0;
 		if (player.input->is_pressed(A_LEFT))		flags |= ServerClient::FLAG_LEFT;
@@ -25,6 +24,7 @@ namespace player_util
 		if (player.input->is_pressed(A_BOMB))		flags |= ServerClient::FLAG_BOMB;
 		if (player.input->is_pressed(A_START))		flags |= ServerClient::FLAG_START;
 
+		playerpos.data.udp_sequence = udpseq;
 		playerpos.data.client_id = player.number;
 		playerpos.data.time = time;
 		playerpos.data.flags = flags;

--- a/Battle/util/stringutils.hpp
+++ b/Battle/util/stringutils.hpp
@@ -1,3 +1,5 @@
+#pragma once
+
 // for converting lower/uppercase 
 // from "C++ Cookbook"
 #include <locale>


### PR DESCRIPTION
Proof of concept containing:
- UDP Packets are linked to client sockets using random 64bit keys.
- UDP Packets have a sequence field, as the time can still yields collisions.
- Sequence fields are checked, and the short field is handled correctly with overflows.
- Only the SetPlayerData command is now transmitted over UDP.

Todo:
- Lag is not calculated on the UDP connection, but on the TCP connection.
- Calculate packet loss, and show indicator somewhere just like with FPS.
