### PR TITLE
Lot's of fixes required to get UDP transmissions (hopefully) stable. :-)

### DIFF
--- a/Battle/commands/CommandCommunicationTokenAck.hpp
+++ b/Battle/commands/CommandCommunicationTokenAck.hpp
@@ -1,0 +1,22 @@
+#pragma once
+
+#include "network/Command.hpp"
+
+class CommandCommunicationTokenAck : public Command
+{
+public:
+
+	CommandCommunicationTokenAck() : Command(Command::Types::CommunicationTokenAck) 
+	{
+		memset(&data, 0x00, sizeof(data));
+	}
+	~CommandCommunicationTokenAck() {	}
+
+	virtual void * getData() { return &data; };
+	virtual size_t getDataLen() { return sizeof(data); };
+
+	struct
+	{
+		Uint32 time;
+	} data;
+};

--- a/Battle/commands/CommandSetClientReady.hpp
+++ b/Battle/commands/CommandSetClientReady.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "network/Command.hpp"
+
+class CommandSetClientReady : public Command
+{
+public:
+
+	CommandSetClientReady () : Command(Command::Types::SetClientReady) { }
+	~CommandSetClientReady() {	}
+
+	virtual void * getData() { return &data; };
+	virtual size_t getDataLen() { return sizeof(data); };
+
+	struct
+	{
+	} data;
+
+private:
+};

--- a/Battle/commands/CommandSetCommunicationToken.hpp
+++ b/Battle/commands/CommandSetCommunicationToken.hpp
@@ -8,16 +8,16 @@ public:
 
 	CommandSetCommunicationToken() : Command(Command::Types::SetCommunicationToken) 
 	{
-		memset(&data, 0x00, sizeof(data));
+		memset(&data_, 0x00, sizeof(data_));
 	}
 	~CommandSetCommunicationToken() {	}
 
-	virtual void * getData() { return &data; };
-	virtual size_t getDataLen() { return sizeof(data); };
+	virtual void * getData() { return &data_; };
+	virtual size_t getDataLen() { return sizeof(data_); };
 
 	struct
 	{
 		Uint32 time;
-		uint64_t commToken;
-	} data;
+		Uint32 commToken;
+	} data_;
 };

--- a/Battle/commands/CommandSetServerReady.hpp
+++ b/Battle/commands/CommandSetServerReady.hpp
@@ -1,0 +1,20 @@
+#pragma once
+
+#include "network/Command.hpp"
+
+class CommandSetServerReady : public Command
+{
+public:
+
+	CommandSetServerReady () : Command(Command::Types::SetServerReady) { }
+	~CommandSetServerReady() {	}
+
+	virtual void * getData() { return &data; };
+	virtual size_t getDataLen() { return sizeof(data); };
+
+	struct
+	{
+	} data;
+
+private:
+};

--- a/Battle/network/Client.h
+++ b/Battle/network/Client.h
@@ -16,6 +16,8 @@ class CommandSetPlayerData;
 class CommandSetClientData;
 class CommandShotFired;
 class CommandBombDropped;
+class CommandCommunicationTokenAck;
+class CommandSetClientReady;
 class Server;
 
 class Client : public CommandProcessor
@@ -25,15 +27,22 @@ public:
 	enum State
 	{
 		CONNECTING = 1,
-		CHARACTER_REQUESTED = 2,
-		CHARACTER_INITIALIZED = 3,
-		ACTIVE = 4
+		COMMTOKEN_REQUESTED,
+		CALCULATING_LAG,
+		INITIALIZING,
+		CHARACTER_REQUESTED,
+		CHARACTER_INITIALIZED,
+		SERVERSIDE_READY,
+		READY_FOR_POSITIONAL_DATA,
+		ACTIVE
 	};
 
 
 	Client(int client_id, TCPsocket socket, Server * const server);
 	Client(Client &&other);
 	Client & operator=(Client&& other);
+	
+	virtual ~Client();
 
 	bool process(std::unique_ptr<Command> command);
 	bool process(CommandPing *command);
@@ -42,6 +51,8 @@ public:
 	bool process(CommandSetPlayerData *command);
 	bool process(CommandShotFired *command);
 	bool process(CommandBombDropped *command);
+	bool process(CommandCommunicationTokenAck *command);
+	bool process(CommandSetClientReady *command);
 
 	// accessors
 	TCPsocket socket() { return socket_; }
@@ -60,7 +71,7 @@ public:
 	void setUDPOrigin(IPaddress address) { address_ = address; }
 	const IPaddress &getUDPOrigin() { return address_; }
 	
-	Uint64 getCommToken() { return commToken_; }
+	Uint32 getCommToken() { return commToken_; }
 	short getLastUdpSeq() { return lastUdpSeq_; }
 
 	// lag
@@ -87,7 +98,9 @@ private:
 
 	Client::State currentState_;
 
-	Uint64 commToken_;
+	Uint32 commToken_;
 	short lastUdpSeq_;
 	IPaddress address_;
+	
+	UDPpacket *p;
 };

--- a/Battle/network/ClientNetworkMultiplayer.cpp
+++ b/Battle/network/ClientNetworkMultiplayer.cpp
@@ -68,7 +68,7 @@ void ClientNetworkMultiplayer::start()
 			}
 
 		}
-		else {
+		else if (ServerClient::getInstance().isCommTokenAvailable()) {
 			Uint32 current = SDL_GetTicks();
 
 			if (initialLagTests > 0) {

--- a/Battle/network/Command.hpp
+++ b/Battle/network/Command.hpp
@@ -32,6 +32,9 @@ public:
 		ApplyPowerup = 0x15,
 		RemovePowerup = 0x16,
 		SetCommunicationToken = 0x17,
+		CommunicationTokenAck = 0x18,
+		SetServerReady = 0x19,
+		SetClientReady = 0x1A,
 	};
 
 	Command::Types getType() const { return type_; }

--- a/Battle/network/CommandProcessor.cpp
+++ b/Battle/network/CommandProcessor.cpp
@@ -1,14 +1,69 @@
 #include "SDL/SDL.h"
 
 #include <memory>
+#include <sstream>
 
 // temp
 #include "network/Client.h"
 
 #include "network/Commands.hpp"
+#include "util/Log.h"
+
+void CommandProcessor::parse_udp(int bytes_received, const char * const buffer)
+{
+	if (bytes_received == 0) {
+		throw std::runtime_error("cannot receive zero bytes");
+	}
+	char expectRequestForBackup = expectRequestFor_;
+	
+	try {
+		std::stringstream ss;
+		ss << format("parse_udp[%d, %d] = ", buffer_idx_, bytes_received);
+		for (int i=0; i<bytes_received; i++) {
+			char p[2] = {0x00};
+			p[0] = buffer[i];
+			ss << format(" %x", *p);
+		}
+		ss << std::endl;
+		log(ss.str(), Logger::Priority::DEBUG);
+		
+		// The expected packet..
+		expectRequestFor_ = buffer[0];
+		
+		auto cmd = Command::factory(static_cast<Command::Types>(expectRequestFor_));
+		size_t requestLen = cmd.get()->getDataLen();
+		if (requestLen != (bytes_received - 1))
+			throw std::runtime_error("unexpected data len for given packet");
+		
+		// Insert the UDP packet data in front (exclude the packet type indicator (the -1))
+		memmove(buffer_ + bytes_received - 1, buffer_, buffer_idx_);
+		buffer_idx_ += bytes_received - 1;
+
+		// Insert the packet in front of the queue
+		memcpy(buffer_, buffer + 1, bytes_received - 1);
+
+		// Parse the data
+		parse();
+		expectRequestFor_ = expectRequestForBackup;
+	}
+	catch (...) {
+		expectRequestFor_ = expectRequestForBackup;
+		throw;
+	}
+}
 
 void CommandProcessor::receive(int bytes_received, const char * const buffer)
 {
+	std::stringstream ss;
+	ss << format("receive[%d, %d] = ", buffer_idx_, bytes_received);
+	for (int i=0; i<bytes_received; i++) {
+		char p[2] = {0x00};
+		p[0] = buffer[i];
+		ss << format(" %x", *p);
+	}
+	ss << std::endl;
+	log(ss.str(), Logger::Priority::DEBUG);
+	
 	memcpy(buffer_ + buffer_idx_,
 					buffer,
 					bytes_received);
@@ -23,17 +78,27 @@ bool CommandProcessor::parse()
 
 	if (expectRequestFor_) {
 
-		try  {
-			auto cmd = Command::factory(static_cast<Command::Types>(expectRequestFor_));
+	try {
+		auto cmd = Command::factory(static_cast<Command::Types>(expectRequestFor_));
 			void *request = cmd.get()->getData();
 			size_t requestLen = cmd.get()->getDataLen();
 
 			if ((size_t)buffer_idx_ >= requestLen) {
+				std::stringstream ss;
+				ss << format("processing[%d, %d] = ", buffer_idx_, requestLen);
+				for (int i=0; i<requestLen; i++) {
+					char p[2] = {0x00};
+					p[0] = *(buffer_ + i);
+					ss << format(" %x", *p);
+				}
+				ss << std::endl;
+				log(ss.str(), Logger::Priority::DEBUG);
+				
 				memcpy(request, buffer_, requestLen);
 
 				cmd.get()->print();
 
-				log(format("Received packet of type %d", expectRequestFor_), Logger::Priority::DEBUG);
+				log(format("Received packet of type 0x%x of length %d", expectRequestFor_, requestLen), Logger::Priority::DEBUG);
 				process(std::move(cmd));
 
 				expectRequestFor_ = 0;
@@ -50,7 +115,10 @@ bool CommandProcessor::parse()
 	else if (static_cast<size_t>(buffer_idx_) >= sizeof(char)) 
 	{
 		expectRequestFor_ = *buffer_;
-
+		char p[2] = {0x00};
+		p[0] = *buffer_;
+		log(format("processing[1] = %x (expectRequestFor is set to this)\n", *p), Logger::Priority::DEBUG);
+		
 		processed += sizeof(char);
 	}
 	

--- a/Battle/network/CommandProcessor.h
+++ b/Battle/network/CommandProcessor.h
@@ -23,12 +23,13 @@ protected:
 	{
 		memset(buffer_, 0x00, sizeof(buffer_));
 	}
-	~CommandProcessor() {}
+	virtual ~CommandProcessor() {}
 
 	void set_socket(TCPsocket socket) { socket_ = socket;}
 
 public:
 
+	void parse_udp(int bytes_received, const char * const buffer);
 	void receive(int bytes_received, const char * const buffer);
 	bool parse();
 	short getUdpSeq() { return udpsequence_; }
@@ -47,7 +48,6 @@ protected:
 	char expectRequestFor_;
 
 	// UDP
-	UDPsocket sd;
-	Uint64 communicationToken_;
+	Uint32 communicationToken_;
 	short udpsequence_;
 };

--- a/Battle/network/Commands.cpp
+++ b/Battle/network/Commands.cpp
@@ -54,6 +54,13 @@ std::unique_ptr<Command> Command::factory(Command::Types type)
 			return std::unique_ptr<Command>(new CommandRemovePowerup());
 		case Command::Types::SetCommunicationToken:
 			return std::unique_ptr<Command>(new CommandSetCommunicationToken());
+		case Command::Types::CommunicationTokenAck:
+			return std::unique_ptr<Command>(new CommandCommunicationTokenAck());
+		case Command::Types::SetServerReady:
+			return std::unique_ptr<Command>(new CommandSetServerReady());
+		case Command::Types::SetClientReady:
+			return std::unique_ptr<Command>(new CommandSetClientReady());
+
 	}
 	throw std::runtime_error("failure");
 }

--- a/Battle/network/Commands.hpp
+++ b/Battle/network/Commands.hpp
@@ -23,3 +23,6 @@
 #include "commands/CommandApplyPowerup.hpp"
 #include "commands/CommandRemovePowerup.hpp"
 #include "commands/CommandSetCommunicationToken.hpp"
+#include "commands/CommandCommunicationTokenAck.hpp"
+#include "commands/CommandSetServerReady.hpp"
+#include "commands/CommandSetClientReady.hpp"

--- a/Battle/network/Server.h
+++ b/Battle/network/Server.h
@@ -87,6 +87,10 @@ public:
 		udpsequence_++;
 	}
 
+	UDPsocket & getUdpSocket() {
+		return sd;
+	}
+	
 private:
 	Server();
 	~Server();
@@ -101,7 +105,7 @@ private:
 	bool is_listening_;
 
 	std::map<int, Client> clients_;
-	std::map<Uint64, int> communicationTokens_;
+	std::map<Uint32, int> communicationTokens_;
 
 	TCPsocket server;
 

--- a/Battle/network/ServerClient.h
+++ b/Battle/network/ServerClient.h
@@ -50,6 +50,7 @@ class CommandGeneratePowerup;
 class CommandApplyPowerup;
 class CommandRemovePowerup;
 class CommandSetCommunicationToken;
+class CommandSetServerReady;
 
 class ServerClient : public CommandProcessor
 {
@@ -91,6 +92,7 @@ public:
 	void send(Command &command);
 
 	bool isConnected() { return is_connected_; }
+	bool isCommTokenAvailable() { return communicationToken_ != 0; }
 	void toggleConsole() { show_console_ = !show_console_ ; }
 	bool showConsole() { return show_console_; }
 
@@ -133,6 +135,7 @@ protected:
 	bool process(CommandApplyPowerup *command);
 	bool process(CommandRemovePowerup *command);
 	bool process(CommandSetCommunicationToken *command);
+	bool process(CommandSetServerReady *command);
 
 	
 private:
@@ -150,6 +153,7 @@ private:
 
 	int character_;
 	IPaddress ip;
+	IPaddress ip2;
 	TCPsocket sock;
 	std::string host_;
 	Uint16 port_;
@@ -179,6 +183,7 @@ private:
 	bool resumeGameWithCountdown_;
 	Uint32 resumeGameTime_;
 	
+	UDPsocket sd;
 	UDPpacket *p;
 
 };


### PR DESCRIPTION
- Moved establishing of "communication token" to front of all communication in separate negotiation state.
- Mark client's "UDP ready" with explicit "Server-ready" / "Client-ready" negotiation.
- Fix UDP for server's clients.
  *_Do not open separate UDP ports for serverclients, just bind them.
  *_Only allocate packet once
  *_Only free packet in destructor, once freed, succesful send's in sdl are no longer guarenteed.
  *_Do not send communicationToken in every packet.
- Fix UDP for client's serverclient.
  *_No longer account for communicationToken from server in UDP packets
  *_Use new parse_udp() function that gives preference to UDP parsing, and prevents "collisions" with TCP data (when parsing)
  *_The communication token is now a Uint32, prevents problems when communicating between 32bit and 64bit platforms. (The sizeof() structs wouldn't match.)
  *_Explicit acknowledgement of SetCommunicationToken.
- Client only sends PING? requests periodically if it has a communicationtoken available.
- New parse_udp that "inserts" the UDP packet in the buffer, so it's processed first. It restores the "expecting packet" state if a TCP packet is not fully received.
- Fix bug in Server where it would attempt to receive UDP packets even though it is not initialized as a server.
- Explicit binding of client remote ip+port to the UDP socket on server. The communicationToken is for extra security.
- Calculating lags on server is an explicit state now. Only handled after commToken is ready.
